### PR TITLE
hotel key

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -2413,3 +2413,7 @@ CE8BFF3728EE
 09938D05DA78
 EACDA4DBE420
 EC2B9FD483CA
+
+# Hotel Intelier Orange - Benicasim, Spain
+# block 1 - key A
+04256CFE0425


### PR DESCRIPTION
Assa Abloy Hotel System in Spain
only block one is used, rest of the card is empty. the key is the same on 5 cards I tested (got the key via mfkey32)